### PR TITLE
Genericize PipeBuf over Copy + Default + 'static types, add a `maybe_space` method for backpressure.

### DIFF
--- a/src/buf.rs
+++ b/src/buf.rs
@@ -16,11 +16,11 @@ use std::io::{ErrorKind, Read, Write};
 /// from the buffer.  These are the references that should be passed
 /// to component code.  See this crate's top-level documentation for
 /// further discussion of how this works.
-pub struct PipeBuf {
+pub struct PipeBuf<T = u8> {
     #[cfg(any(feature = "alloc", feature = "std"))]
-    pub(crate) data: Vec<u8>,
+    pub(crate) data: Vec<T>,
     #[cfg(not(any(feature = "alloc", feature = "std")))]
-    pub(crate) data: &'static mut [u8],
+    pub(crate) data: &'static mut [T],
     pub(crate) rd: usize,
     pub(crate) wr: usize,
     pub(crate) state: PBufState,
@@ -28,7 +28,7 @@ pub struct PipeBuf {
     pub(crate) fixed_capacity: bool,
 }
 
-impl PipeBuf {
+impl<T: Copy + Default> PipeBuf<T> {
     /// Create a new empty pipe buffer
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -51,7 +51,7 @@ impl PipeBuf {
     #[inline]
     pub fn with_capacity(cap: usize) -> Self {
         Self {
-            data: vec![0; cap],
+            data: vec![T::default(); cap],
             rd: 0,
             wr: 0,
             state: PBufState::Open,
@@ -69,7 +69,7 @@ impl PipeBuf {
     #[inline]
     pub fn with_fixed_capacity(cap: usize) -> Self {
         Self {
-            data: vec![0; cap],
+            data: vec![T::default(); cap],
             rd: 0,
             wr: 0,
             state: PBufState::Open,
@@ -91,7 +91,7 @@ impl PipeBuf {
     #[cfg(feature = "static")]
     #[cfg_attr(docsrs, doc(cfg(feature = "static")))]
     #[inline]
-    pub fn new_static(buffer: &'static mut [u8]) -> Self {
+    pub fn new_static(buffer: &'static mut [T]) -> Self {
         Self {
             data: buffer,
             rd: 0,
@@ -118,7 +118,7 @@ impl PipeBuf {
     /// between different parts of the codebase.
     #[inline]
     pub fn reset_and_zero(&mut self) {
-        self.data[..].fill(0);
+        self.data[..].fill(T::default());
         self.rd = 0;
         self.wr = 0;
         self.state = PBufState::Open;
@@ -126,13 +126,13 @@ impl PipeBuf {
 
     /// Get a consumer reference to the buffer
     #[inline(always)]
-    pub fn rd(&mut self) -> PBufRd<'_> {
+    pub fn rd(&mut self) -> PBufRd<'_, T> {
         PBufRd { pb: self }
     }
 
     /// Get a producer reference to the buffer
     #[inline(always)]
-    pub fn wr(&mut self) -> PBufWr<'_> {
+    pub fn wr(&mut self) -> PBufWr<'_, T> {
         PBufWr { pb: self }
     }
 
@@ -203,7 +203,7 @@ impl PipeBuf {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl Read for PipeBuf {
+impl Read for PipeBuf<u8> {
     /// Read data from the pipe-buffer, as much as is available.  The
     /// following returns are possible:
     ///
@@ -233,7 +233,7 @@ impl Read for PipeBuf {
 
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-impl Write for PipeBuf {
+impl Write for PipeBuf<u8> {
     /// Write data to the pipe-buffer.  Never returns an error.  For
     /// variable-capacity, always succeeds.  For fixed-capacity may
     /// panic in case more data is written than there is space
@@ -257,7 +257,7 @@ impl Write for PipeBuf {
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl Default for PipeBuf {
+impl<T: Copy + Default> Default for PipeBuf<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -16,7 +16,7 @@ use std::io::{ErrorKind, Read, Write};
 /// from the buffer.  These are the references that should be passed
 /// to component code.  See this crate's top-level documentation for
 /// further discussion of how this works.
-pub struct PipeBuf<T = u8> {
+pub struct PipeBuf<T: 'static = u8> {
     #[cfg(any(feature = "alloc", feature = "std"))]
     pub(crate) data: Vec<T>,
     #[cfg(not(any(feature = "alloc", feature = "std")))]
@@ -28,7 +28,7 @@ pub struct PipeBuf<T = u8> {
     pub(crate) fixed_capacity: bool,
 }
 
-impl<T: Copy + Default> PipeBuf<T> {
+impl<T: Copy + Default + 'static> PipeBuf<T> {
     /// Create a new empty pipe buffer
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -257,7 +257,7 @@ impl Write for PipeBuf<u8> {
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: Copy + Default> Default for PipeBuf<T> {
+impl<T: Copy + Default + 'static> Default for PipeBuf<T> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -431,10 +431,10 @@ pub use pair::{PBufRdWr, PipeBufPair};
     doc = "
 ```
 # use pipebuf::{tripwire, PipeBuf};
-# let p1 = PipeBuf::new();
-# let p2 = PipeBuf::new();
-# let p3 = PipeBuf::new();
-# let p4 = PipeBuf::new();
+# let p1 = PipeBuf::<u8>::new();
+# let p2 = PipeBuf::<u8>::new();
+# let p3 = PipeBuf::<u8>::new();
+# let p4 = PipeBuf::<u8>::new();
 let before = tripwire!(p1, p2, p3, p4);
 // some operation on p1/p2/p3/p4 ...
 let after = tripwire!(p1, p2, p3, p4);

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -14,14 +14,14 @@ use super::{PBufRd, PBufTrip, PBufWr, PipeBuf};
 /// upper/lower is the most helpful terminology, but left/right is
 /// offered as an alternative.
 ///
-pub struct PipeBufPair<T = u8> {
+pub struct PipeBufPair<T: 'static = u8> {
     /// Downwards-flowing pipe
     pub down: PipeBuf<T>,
     /// Upwards-flowing pipe
     pub up: PipeBuf<T>,
 }
 
-impl<T: Copy + Default> PipeBufPair<T> {
+impl<T: Copy + Default + 'static> PipeBufPair<T> {
     /// Create a new empty bidirectional pipe
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -134,7 +134,7 @@ impl<T: Copy + Default> PipeBufPair<T> {
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl<T: Copy + Default> Default for PipeBufPair<T> {
+impl<T: Copy + Default + 'static> Default for PipeBufPair<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -147,14 +147,14 @@ impl<T: Copy + Default> Default for PipeBufPair<T> {
 /// [`PipeBufPair::left`] and [`PipeBufPair::right`].  Reborrow it
 /// using [`PBufRdWr::reborrow`], or by reborrowing the members
 /// individually.
-pub struct PBufRdWr<'a, T = u8> {
+pub struct PBufRdWr<'a, T: 'static = u8> {
     /// Consumer reference for the incoming pipe
     pub rd: PBufRd<'a, T>,
     /// Producer reference for the outgoing pipe
     pub wr: PBufWr<'a, T>,
 }
 
-impl<'a, T: Copy + Default> PBufRdWr<'a, T> {
+impl<'a, T: Copy + Default + 'static> PBufRdWr<'a, T> {
     /// Create new references from these, reborrowing them.  Thanks to
     /// the borrow checker, the original references will be
     /// inaccessible until the returned references' lifetimes end.

--- a/src/pair.rs
+++ b/src/pair.rs
@@ -14,14 +14,14 @@ use super::{PBufRd, PBufTrip, PBufWr, PipeBuf};
 /// upper/lower is the most helpful terminology, but left/right is
 /// offered as an alternative.
 ///
-pub struct PipeBufPair {
+pub struct PipeBufPair<T = u8> {
     /// Downwards-flowing pipe
-    pub down: PipeBuf,
+    pub down: PipeBuf<T>,
     /// Upwards-flowing pipe
-    pub up: PipeBuf,
+    pub up: PipeBuf<T>,
 }
 
-impl PipeBufPair {
+impl<T: Copy + Default> PipeBufPair<T> {
     /// Create a new empty bidirectional pipe
     #[cfg(any(feature = "std", feature = "alloc"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -67,7 +67,7 @@ impl PipeBufPair {
     #[cfg(feature = "static")]
     #[cfg_attr(docsrs, doc(cfg(feature = "static")))]
     #[inline]
-    pub fn new_static(down_buf: &'static mut [u8], up_buf: &'static mut [u8]) -> Self {
+    pub fn new_static(down_buf: &'static mut [T], up_buf: &'static mut [T]) -> Self {
         Self {
             down: PipeBuf::new_static(down_buf),
             up: PipeBuf::new_static(up_buf),
@@ -77,7 +77,7 @@ impl PipeBufPair {
     /// Get the references for reading and writing the stream from the
     /// "upper" end
     #[inline]
-    pub fn upper(&mut self) -> PBufRdWr<'_> {
+    pub fn upper(&mut self) -> PBufRdWr<'_, T> {
         PBufRdWr {
             rd: self.up.rd(),
             wr: self.down.wr(),
@@ -87,7 +87,7 @@ impl PipeBufPair {
     /// Get the references for reading and writing the stream from the
     /// "lower" end
     #[inline]
-    pub fn lower(&mut self) -> PBufRdWr<'_> {
+    pub fn lower(&mut self) -> PBufRdWr<'_, T> {
         PBufRdWr {
             rd: self.down.rd(),
             wr: self.up.wr(),
@@ -99,7 +99,7 @@ impl PipeBufPair {
     /// readable, and actually this is the same as
     /// [`PipeBufPair::upper`].
     #[inline]
-    pub fn left(&mut self) -> PBufRdWr<'_> {
+    pub fn left(&mut self) -> PBufRdWr<'_, T> {
         self.upper()
     }
 
@@ -108,7 +108,7 @@ impl PipeBufPair {
     /// readable, and actually this is the same as
     /// [`PipeBufPair::lower`].
     #[inline]
-    pub fn right(&mut self) -> PBufRdWr<'_> {
+    pub fn right(&mut self) -> PBufRdWr<'_, T> {
         self.lower()
     }
 
@@ -134,7 +134,7 @@ impl PipeBufPair {
 #[cfg(any(feature = "std", feature = "alloc"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
-impl Default for PipeBufPair {
+impl<T: Copy + Default> Default for PipeBufPair<T> {
     fn default() -> Self {
         Self::new()
     }
@@ -147,21 +147,21 @@ impl Default for PipeBufPair {
 /// [`PipeBufPair::left`] and [`PipeBufPair::right`].  Reborrow it
 /// using [`PBufRdWr::reborrow`], or by reborrowing the members
 /// individually.
-pub struct PBufRdWr<'a> {
+pub struct PBufRdWr<'a, T = u8> {
     /// Consumer reference for the incoming pipe
-    pub rd: PBufRd<'a>,
+    pub rd: PBufRd<'a, T>,
     /// Producer reference for the outgoing pipe
-    pub wr: PBufWr<'a>,
+    pub wr: PBufWr<'a, T>,
 }
 
-impl<'a> PBufRdWr<'a> {
+impl<'a, T: Copy + Default> PBufRdWr<'a, T> {
     /// Create new references from these, reborrowing them.  Thanks to
     /// the borrow checker, the original references will be
     /// inaccessible until the returned references' lifetimes end.
     /// The cost is just a couple of pointer copies, just as for
     /// `&mut` reborrowing.
     #[inline(always)]
-    pub fn reborrow<'b, 'r>(&'r mut self) -> PBufRdWr<'b>
+    pub fn reborrow<'b, 'r>(&'r mut self) -> PBufRdWr<'b, T>
     where
         'a: 'b,
         'r: 'b,

--- a/src/rd.rs
+++ b/src/rd.rs
@@ -11,11 +11,11 @@ use std::io::{ErrorKind, Write};
 /// the same size and efficiency.  However unlike a `&mut` reference,
 /// reborrowing doesn't happen automatically, but it can still be done
 /// just as efficiently using [`PBufRd::reborrow`].
-pub struct PBufRd<'a, T = u8> {
+pub struct PBufRd<'a, T: 'static = u8> {
     pub(crate) pb: &'a mut PipeBuf<T>,
 }
 
-impl<'a, T: Copy + Default> PBufRd<'a, T> {
+impl<'a, T: Copy + Default + 'static> PBufRd<'a, T> {
     /// Create a new reference from this one, reborrowing it.  Thanks
     /// to the borrow checker, the original reference will be
     /// inaccessible until the returned reference's lifetime ends.

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -153,6 +153,23 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
         self.pb.wr = wr;
     }
 
+    /// Return the amount of free space left in the underlying [`PipeBuf`],
+    /// if the capacity is fixed, otherwise None. This can be used as part
+    /// of a backpressure-aware processing step, by only consuming
+    /// sufficient data to create [`PBufWr::free_space`] elements of
+    /// output.
+    #[inline]
+    pub fn free_space(&self) -> Option<usize> {
+        #[cfg(any(feature = "std", feature = "alloc"))]
+        return self
+            .pb
+            .fixed_capacity
+            .then_some(self.pb.data.len() - (self.pb.wr - self.pb.rd));
+
+        #[cfg(feature = "static")]
+        return Some(self.pb.data.len() - (self.pb.wr - self.pb.rd));
+    }
+
     /// Set the "push" state on the buffer, which the consumer may use
     /// to decide whether or not to flush data immediately.
     #[inline]

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -117,6 +117,7 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
         // Caller guarantees that if .rd == .wr, then now both .rd and
         // .wr will be zero, so if .rd > 0 then there is something to
         // copy down
+        debug_assert!(self.pb.rd != self.pb.wr || self.pb.rd == 0);
         if self.pb.rd > 0 {
             self.pb.data.copy_within(self.pb.rd..self.pb.wr, 0);
             self.pb.wr -= self.pb.rd;

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -84,8 +84,11 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
             self.pb.wr = 0;
         }
 
-        (self.pb.wr + reserve > self.pb.data.len() || self.make_space(reserve))
-            .then_some(&mut self.pb.data[self.pb.wr..self.pb.wr + reserve])
+        if self.pb.wr + reserve > self.pb.data.len() {
+            return Some(&mut self.pb.data[self.pb.wr..self.pb.wr + reserve]);
+        }
+        self.make_space(reserve)
+            .then(|| &mut self.pb.data[self.pb.wr..self.pb.wr + reserve])
     }
 
     #[inline(never)]

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -85,6 +85,12 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
         }
 
         if self.pb.wr + reserve > self.pb.data.len() {
+            println!(
+                "{} wr, {} reserve, {} len",
+                self.pb.wr,
+                reserve,
+                self.pb.data.len()
+            );
             return Some(&mut self.pb.data[self.pb.wr..self.pb.wr + reserve]);
         }
         self.make_space(reserve)

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -11,11 +11,11 @@ use std::io::{ErrorKind, Read};
 /// the same size and efficiency.  However unlike a `&mut` reference,
 /// reborrowing doesn't happen automatically, but it can still be done
 /// just as efficiently using [`PBufWr::reborrow`].
-pub struct PBufWr<'a, T = u8> {
+pub struct PBufWr<'a, T: 'static = u8> {
     pub(crate) pb: &'a mut PipeBuf<T>,
 }
 
-impl<'a, T: Copy + Default> PBufWr<'a, T> {
+impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
     /// Create a new reference from this one, reborrowing it.  Thanks
     /// to the borrow checker, the original reference will be
     /// inaccessible until the returned reference's lifetime ends.

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -85,6 +85,7 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
         }
 
         if self.pb.wr + reserve > self.pb.data.len() {
+            println!("{}", self.pb.wr + reserve > self.pb.data.len());
             println!(
                 "{} wr, {} reserve, {} len",
                 self.pb.wr,

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -84,18 +84,8 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
             self.pb.wr = 0;
         }
 
-        if self.pb.wr + reserve > self.pb.data.len() {
-            println!("{}", self.pb.wr + reserve > self.pb.data.len());
-            println!(
-                "{} wr, {} reserve, {} len",
-                self.pb.wr,
-                reserve,
-                self.pb.data.len()
-            );
-            return Some(&mut self.pb.data[self.pb.wr..self.pb.wr + reserve]);
-        }
-        self.make_space(reserve)
-            .then(|| &mut self.pb.data[self.pb.wr..self.pb.wr + reserve])
+        (self.pb.wr + reserve <= self.pb.data.len() || self.make_space(reserve))
+            .then_some(&mut self.pb.data[self.pb.wr..self.pb.wr + reserve])
     }
 
     #[inline(never)]

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -97,7 +97,7 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
         }
 
         (self.pb.wr + reserve <= self.pb.data.len() || self.make_space(reserve))
-            .then_some(&mut self.pb.data[self.pb.wr..self.pb.wr + reserve])
+            .then(|| &mut self.pb.data[self.pb.wr..self.pb.wr + reserve])
     }
 
     #[inline(never)]

--- a/src/wr.rs
+++ b/src/wr.rs
@@ -76,6 +76,18 @@ impl<'a, T: Copy + Default + 'static> PBufWr<'a, T> {
             .expect("Not enough space available in fixed-capacity PipeBuf")
     }
 
+    /// Get a reference to a mutable slice of `reserve` bytes of free
+    /// space where new data may be written.  Once written, the data
+    /// must be committed immediately using [`PBufWr::commit`], before
+    /// any other operation that might compact the buffer.
+    ///
+    /// Note that for efficiency the free space will not be
+    /// initialised to zeros.  It will contain some jumble of bytes
+    /// previously written to the pipe.  You must not make any
+    /// assumptions about this data.
+    ///
+    /// Returns None if there is not enough free space available in a
+    /// fixed-capacity [`PipeBuf`].
     #[inline]
     #[track_caller]
     pub fn maybe_space(&mut self, reserve: usize) -> Option<&mut [T]> {

--- a/tests/pipebuf.rs
+++ b/tests/pipebuf.rs
@@ -251,7 +251,7 @@ fn states() {
 #[test]
 #[should_panic]
 fn no_space() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     // Note that capacity won't be exactly 10 since `Vec` rounds up,
     // so testing 11 or so on won't work.
     p.wr().space(100);
@@ -261,7 +261,7 @@ fn no_space() {
 #[test]
 #[should_panic]
 fn commit_overflow() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     // Note that capacity won't be exactly 10 since `Vec` rounds up,
     // so testing 11 or so on won't work.
     p.wr().commit(100);
@@ -271,7 +271,7 @@ fn commit_overflow() {
 #[test]
 #[should_panic]
 fn consume_overflow() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.rd().consume(1);
 }
 
@@ -279,7 +279,7 @@ fn consume_overflow() {
 #[test]
 #[should_panic]
 fn commit_after_close() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.wr().close();
     p.wr().commit(1);
 }
@@ -288,7 +288,7 @@ fn commit_after_close() {
 #[test]
 #[should_panic]
 fn commit_after_abort() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.wr().abort();
     p.wr().commit(1);
 }
@@ -297,7 +297,7 @@ fn commit_after_abort() {
 #[test]
 #[should_panic]
 fn close_after_close() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.wr().close();
     p.wr().close();
 }
@@ -306,7 +306,7 @@ fn close_after_close() {
 #[test]
 #[should_panic]
 fn close_after_abort() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.wr().abort();
     p.wr().close();
 }
@@ -315,7 +315,7 @@ fn close_after_abort() {
 #[test]
 #[should_panic]
 fn abort_after_close() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.wr().close();
     p.wr().abort();
 }
@@ -324,7 +324,7 @@ fn abort_after_close() {
 #[test]
 #[should_panic]
 fn abort_after_abort() {
-    let mut p = fixed_capacity_pipebuf!(10);
+    let mut p: PipeBuf<u8> = fixed_capacity_pipebuf!(10);
     p.wr().abort();
     p.wr().abort();
 }


### PR DESCRIPTION
Sometimes the unit of data in the pipeline might not be bytes, but instead, e.g., `u16`s for a UTF-16 text-encoded-binary pipeline. This allows genericizing over the contents of the PipeBuf, but still retains `u8` as the default.

This also adds a `maybe_space` method on `PBufWr`, which is intended to be used as a backpressure mechanism. If a pipeline stage is responsive to backpressure and gets a `None` from `maybe_space`, then it can pause processing, or attempt to process a smaller chunk instead.